### PR TITLE
Fix Dockerfile to change from ADD to COPY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-node_modules
+# Node dependencies
+node_modules/
+
+# IntelliJ
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:7.8.0
 WORKDIR /app
-ADD . /app
+COPY . /app
 EXPOSE 3000
 CMD ["npm", "run", "production"]


### PR DESCRIPTION
- Ideally we should use COPY, ADD is used in case where we want
  to extract some tar file etc into the path.